### PR TITLE
Pin iOS Podspec versions

### DIFF
--- a/ios/Classes/AdmobBanner.swift
+++ b/ios/Classes/AdmobBanner.swift
@@ -73,7 +73,6 @@ class AdmobBanner : NSObject, FlutterPlatformView {
     fileprivate func requestAd() {
         if let ad = getBannerAdView() {
             let request = GADRequest()
-            GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [kGADSimulatorID as! String]
             ad.load(request)
         }
     }

--- a/ios/Classes/AdmobInterstitialPlugin.swift
+++ b/ios/Classes/AdmobInterstitialPlugin.swift
@@ -80,7 +80,6 @@ public class AdmobIntersitialPlugin: NSObject, FlutterPlugin {
     private func loadInterstantialAd(id: Int, interstantialAdUnitId: String) {
         let interstantial = getInterstitialAd(id: id, interstantialAdUnitId: interstantialAdUnitId)
         let request = GADRequest()
-        GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [kGADSimulatorID as! String]
         interstantial.load(request)
     }
     

--- a/ios/Classes/AdmobRewardPlugin.swift
+++ b/ios/Classes/AdmobRewardPlugin.swift
@@ -87,7 +87,6 @@ public class AdmobRewardPlugin: NSObject, FlutterPlugin {
     private func loadRewardBasedVideoAd(id: Int, rewardBasedVideoAdUnitId: String) {
         let interstantial = getRewardBasedVideoAd(id: id)
         let request = GADRequest()
-        GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = [kGADSimulatorID as! String]
         interstantial.load(request, withAdUnitID: rewardBasedVideoAdUnitId)
     }
     

--- a/ios/Classes/SwiftAdmobFlutterPlugin.swift
+++ b/ios/Classes/SwiftAdmobFlutterPlugin.swift
@@ -36,7 +36,12 @@ public class SwiftAdmobFlutterPlugin: NSObject, FlutterPlugin {
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case "initialize":
-        GADMobileAds.sharedInstance().start(completionHandler: nil)
+        // https://developers.google.com/admob/ios/test-ads#enable_test_devices
+        // **iOS simulators are automatically configured as test devices.**
+        // GADMobileAds.sharedInstance().requestConfiguration.testDeviceIdentifiers = ["You're physical iDevice Id"]
+        GADMobileAds.sharedInstance().start { (status: GADInitializationStatus) in
+            print("iOS Admob status: \(status.adapterStatusesByClassName)")
+        }
         break
     default:
         result(FlutterMethodNotImplemented)

--- a/ios/admob_flutter.podspec
+++ b/ios/admob_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'admob_flutter'
-  s.version          = '0.3.2'
+  s.version          = '0.3.4'
   s.swift_version    = '5.0'
   s.summary          = 'Admob plugin that shows banner ads using native platform views.'
   s.description      = <<-DESC
@@ -16,8 +16,13 @@ Admob plugin that shows banner ads using native platform views.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Core'
+  
+  # https://firebase.google.com/docs/ios/setup
+  # https://github.com/CocoaPods/Specs/blob/master/Specs/0/3/5/Firebase/6.10.0/Firebase.podspec.json
+  s.dependency 'Firebase/Analytics'
+  s.dependency 'FirebaseAnalytics', '~> 6.1.3'
   s.dependency 'Firebase/AdMob'
+  s.dependency 'Google-Mobile-Ads-SDK', '~> 7.50'
 
   s.ios.deployment_target = '8.0'
   s.static_framework = true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: admob_flutter
 description: Admob plugin that shows banner ads using native platform views.
-version: 0.3.3
+version: 0.3.4
 author: Youssef Kababe <youssef.kbe@gmail.com>
 homepage: https://github.com/YoussefKababe/admob_flutter
 


### PR DESCRIPTION
Pinning the iOS versions required for Admob to work. This will address, https://github.com/YoussefKababe/admob_flutter/issues/74, for the future. If users didn't `update` their pods (which apparently Flutter doesn't do for you) you could be stuck with an old version of the ad SDK, hence it doesn't know about the new functionality.

🚀 